### PR TITLE
fix: add try except block to skip stream with errors

### DIFF
--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -281,6 +281,12 @@ class Stream():
 
         This is the default implementation. Get's all of self's objects
         and calls to_dict on them with no further processing.
+
+        If the get_objects() function throws an error (due to access permission,...)
+        return immediately to skip stream
         """
-        for obj in self.get_objects():
-            yield obj.to_dict()
+        try:
+            for obj in self.get_objects():
+                yield obj.to_dict()
+        except:
+            return

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -285,8 +285,5 @@ class Stream():
         If the get_objects() function throws an error (due to access permission,...)
         return immediately to skip stream
         """
-        try:
-            for obj in self.get_objects():
-                yield obj.to_dict()
-        except:
-            return
+        for obj in self.get_objects():
+            yield obj.to_dict()

--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -281,9 +281,6 @@ class Stream():
 
         This is the default implementation. Get's all of self's objects
         and calls to_dict on them with no further processing.
-
-        If the get_objects() function throws an error (due to access permission,...)
-        return immediately to skip stream
         """
         for obj in self.get_objects():
             yield obj.to_dict()


### PR DESCRIPTION
# Description of change
If the get_objects() function throws an error (due to access permission,...) return immediately to skip stream.

