### PR TITLE
Fix: use generic backoff generator expo

### DIFF
--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -94,18 +94,6 @@ def retry_handler(details):
     LOGGER.info("Received 500 or retryable error -- Retry %s/%s",
                 details['tries'], MAX_RETRIES)
 
-#pylint: disable=unused-argument
-def retry_after_wait_gen(**kwargs):
-    # This is called in an except block so we can retrieve the exception
-    # and check it.
-    exc_info = sys.exc_info()
-    resp = exc_info[1].response
-    # Retry-After is an undocumented header. But honoring
-    # it was proven to work in our spikes.
-    # It's been observed to come through as lowercase, so fallback if not present
-    sleep_time_str = resp.headers.get('Retry-After', resp.headers.get('retry-after'))
-    yield math.floor(float(sleep_time_str))
-
 # boolean function to check if the error is 'timeout' error or not
 def is_timeout_error(error_raised):
     """
@@ -130,12 +118,13 @@ def shopify_error_handling(fnc):
                           giveup=is_not_status_code_fn(range(500, 599)),
                           on_backoff=retry_handler,
                           max_tries=MAX_RETRIES)
-    @backoff.on_exception(retry_after_wait_gen,
+    @backoff.on_exception(backoff.expo,
                           pyactiveresource.connection.ClientError,
                           giveup=is_not_status_code_fn([429]),
                           on_backoff=leaky_bucket_handler,
                           # No jitter as we want a constant value
-                          jitter=None)
+                          jitter=None,
+                          factor=2)
     @functools.wraps(fnc)
     def wrapper(*args, **kwargs):
         return fnc(*args, **kwargs)


### PR DESCRIPTION
# Description of change
After updating backoff version of singer-python, the backoff decorator was not working properly. This is because backoff sends and empty initialisation (None) which causes the generator to break. The solution was to use backoffs expo wait generator with a factor 2. (i.e. 2 seconds or more).

