### PR TITLE
[fix] 🔢 updating tap version to 2024-01 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-shopify",
-    version="1.6.2",
+    version="1.10.0",
     description="Singer.io tap for extracting Shopify data",
     author="Stitch",
     url="http://github.com/singer-io/tap-shopify",
@@ -11,12 +11,12 @@ setup(
     python_requires='>=3.5.2',
     py_modules=["tap_shopify"],
     install_requires=[
-        "ShopifyAPI @ git+https://github.com/peliqan-io/shopify_python_api@master",
+        "ShopifyAPI @ git+https://github.com/Peliqan-io/shopify_python_api@master",
         "singer-python @ git+https://github.com/peliqan-io/singer-python@master",
     ],
     extras_require={
         'dev': [
-            'pylint==2.7.4',
+            'pylint==3.0.3',
             'ipdb',
             'requests==2.20.0',
             'nose',

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -25,7 +25,7 @@ SDC_KEYS = {'id': 'integer', 'name': 'string', 'myshopify_domain': 'string'}
 def initialize_shopify_client():
     api_key = Context.config['api_key']
     shop = Context.config['shop']
-    version = '2022-07'
+    version = '2024-01'
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
 

--- a/tap_shopify/schemas/definitions.json
+++ b/tap_shopify/schemas/definitions.json
@@ -3,939 +3,455 @@
     "items": {
       "properties": {
         "amount_set": {
-          "type": [
-            "null",
-            "object"
-          ]
+          "type": ["null", "object"]
         },
         "tax_amount_set": {
-          "type": [
-            "null",
-            "object"
-          ]
+          "type": ["null", "object"]
         },
         "order_id": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "tax_amount": {
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "singer.decimal"
         },
         "refund_id": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "amount": {
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "singer.decimal"
         },
         "kind": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "id": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "reason": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         }
       },
-      "type": [
-        "null",
-        "object"
-      ]
+      "type": ["null", "object"]
     },
-    "type": [
-      "null",
-      "array"
-    ]
+    "type": ["null", "array"]
   },
   "customer": {
-    "type": [
-      "null",
-      "object"
-    ],
+    "type": ["null", "object"],
     "properties": {
       "last_order_name": {
-        "type": [
-          "null",
-          "string"
-        ]
-      },
-      "currency": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "email": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "multipass_identifier": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "default_address": {
-        "type": [
-          "null",
-          "object"
-        ],
+        "type": ["null", "object"],
         "properties": {
           "city": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "address1": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "zip": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "id": {
-            "type": [
-              "null",
-              "integer"
-            ]
+            "type": ["null", "integer"]
           },
           "country_name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "province": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "phone": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "country": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "first_name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "customer_id": {
-            "type": [
-              "null",
-              "integer"
-            ]
+            "type": ["null", "integer"]
           },
           "default": {
-            "type": [
-              "null",
-              "boolean"
-            ]
+            "type": ["null", "boolean"]
           },
           "last_name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "country_code": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "province_code": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "address2": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "company": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "orders_count": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       },
       "state": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "verified_email": {
-        "type": [
-          "null",
-          "boolean"
-        ]
+        "type": ["null", "boolean"]
       },
       "total_spent": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "last_order_id": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       },
       "first_name": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "updated_at": {
-        "type": [
-          "null",
-          "string"
-        ],
+        "type": ["null", "string"],
         "format": "date-time"
       },
       "note": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "phone": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "admin_graphql_api_id": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "addresses": {
-        "type": [
-          "null",
-          "array"
-        ],
+        "type": ["null", "array"],
         "items": {
-          "type": [
-            "null",
-            "object"
-          ],
+          "type": ["null", "object"],
           "properties": {
             "city": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "address1": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "zip": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "id": {
-              "type": [
-                "null",
-                "integer"
-              ]
+              "type": ["null", "integer"]
             },
             "country_name": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "province": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "phone": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "country": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "first_name": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "customer_id": {
-              "type": [
-                "null",
-                "integer"
-              ]
+              "type": ["null", "integer"]
             },
             "default": {
-              "type": [
-                "null",
-                "boolean"
-              ]
+              "type": ["null", "boolean"]
             },
             "last_name": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "country_code": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "name": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "province_code": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "address2": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "company": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           }
         }
       },
       "last_name": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "tags": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "tax_exempt": {
-        "type": [
-          "null",
-          "boolean"
-        ]
+        "type": ["null", "boolean"]
       },
       "id": {
-        "type": [
-          "null",
-          "integer"
-        ]
-      },
-      "accepts_marketing": {
-        "type": [
-          "null",
-          "boolean"
-        ]
-      },
-      "accepts_marketing_updated_at": {
-        "anyOf": [
-          {
-            "type": "string" ,
-            "format": "date-time"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ]
+        "type": ["null", "integer"]
       },
       "created_at": {
-        "type": [
-          "null",
-          "string"
-        ],
+        "type": ["null", "string"],
         "format": "date-time"
       },
       "tax_exemptions": {
-        "type": [
-          "null",
-          "array"
-        ],
+        "type": ["null", "array"],
         "items": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         }
       },
-      "marketing_opt_in_level": {
-        "type": [
-          "null",
-          "string"
-        ]
-      },
       "email_marketing_consent": {
-        "type": [
-          "null",
-          "object"
-        ],
+        "type": ["null", "object"],
         "properties": {
           "state": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "opt_in_level": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "consent_updated_at": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           }
         }
       },
       "sms_marketing_consent": {
-        "type": [
-          "null",
-          "object"
-        ],
+        "type": ["null", "object"],
         "properties": {
           "state": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "opt_in_level": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "consent_updated_at": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "consent_collected_from": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       }
     }
   },
   "customer_orders": {
-    "type": [
-      "null",
-      "object"
-    ],
+    "type": ["null", "object"],
     "properties": {
       "currency": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "email": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "multipass_identifier": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "default_address": {
-        "type": [
-          "null",
-          "object"
-        ],
+        "type": ["null", "object"],
         "properties": {
           "city": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "address1": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "zip": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "id": {
-            "type": [
-              "null",
-              "integer"
-            ]
+            "type": ["null", "integer"]
           },
           "country_name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "province": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "phone": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "country": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "first_name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "customer_id": {
-            "type": [
-              "null",
-              "integer"
-            ]
+            "type": ["null", "integer"]
           },
           "default": {
-            "type": [
-              "null",
-              "boolean"
-            ]
+            "type": ["null", "boolean"]
           },
           "last_name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "country_code": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "province_code": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "address2": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "company": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "state": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "verified_email": {
-        "type": [
-          "null",
-          "boolean"
-        ]
+        "type": ["null", "boolean"]
       },
       "first_name": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "updated_at": {
-        "type": [
-          "null",
-          "string"
-        ],
+        "type": ["null", "string"],
         "format": "date-time"
       },
       "note": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "phone": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "admin_graphql_api_id": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "addresses": {
-        "type": [
-          "null",
-          "array"
-        ],
+        "type": ["null", "array"],
         "items": {
-          "type": [
-            "null",
-            "object"
-          ],
+          "type": ["null", "object"],
           "properties": {
             "city": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "address1": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "zip": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "id": {
-              "type": [
-                "null",
-                "integer"
-              ]
+              "type": ["null", "integer"]
             },
             "country_name": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "province": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "phone": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "country": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "first_name": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "customer_id": {
-              "type": [
-                "null",
-                "integer"
-              ]
+              "type": ["null", "integer"]
             },
             "default": {
-              "type": [
-                "null",
-                "boolean"
-              ]
+              "type": ["null", "boolean"]
             },
             "last_name": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "country_code": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "name": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "province_code": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "address2": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
             "company": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           }
         }
       },
       "last_name": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "tags": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "tax_exempt": {
-        "type": [
-          "null",
-          "boolean"
-        ]
+        "type": ["null", "boolean"]
       },
       "id": {
-        "type": [
-          "null",
-          "integer"
-        ]
-      },
-      "accepts_marketing": {
-        "type": [
-          "null",
-          "boolean"
-        ]
-      },
-      "accepts_marketing_updated_at": {
-        "anyOf": [
-          {
-            "type": "string" ,
-            "format": "date-time"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ]
+        "type": ["null", "integer"]
       },
       "created_at": {
-        "type": [
-          "null",
-          "string"
-        ],
+        "type": ["null", "string"],
         "format": "date-time"
       },
       "tax_exemptions": {
-        "type": [
-          "null",
-          "array"
-        ],
+        "type": ["null", "array"],
         "items": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         }
       },
-      "marketing_opt_in_level": {
-        "type": [
-          "null",
-          "string"
-        ]
-      },
       "email_marketing_consent": {
-        "type": [
-          "null",
-          "object"
-        ],
+        "type": ["null", "object"],
         "properties": {
           "state": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "opt_in_level": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "consent_updated_at": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           }
         }
       },
       "sms_marketing_consent": {
-        "type": [
-          "null",
-          "object"
-        ],
+        "type": ["null", "object"],
         "properties": {
           "state": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "opt_in_level": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "consent_updated_at": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "consent_collected_from": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       }
@@ -944,193 +460,104 @@
   "location": {
     "properties": {
       "country_code": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "name": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "address1": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "city": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "id": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       },
       "address2": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "province_code": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "zip": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "localized_province_name": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "localized_country_name": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "updated_at": {
-        "type": [
-          "null",
-          "string"
-        ],
+        "type": ["null", "string"],
         "format": "date-time"
       },
       "province": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "phone": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "legacy": {
-        "type": [
-          "null",
-          "boolean"]
+        "type": ["null", "boolean"]
       },
       "created_at": {
-        "type": [
-          "null",
-          "string"
-        ],
+        "type": ["null", "string"],
         "format": "date-time"
       },
       "country": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "active": {
-        "type": [
-          "null",
-          "boolean"]
+        "type": ["null", "boolean"]
       },
       "admin_graphql_api_id": {
-        "type": [
-          "null",
-          "string"]
+        "type": ["null", "string"]
       },
       "country_name": {
-        "type": [
-          "null",
-          "string"]
+        "type": ["null", "string"]
       }
     },
-    "type": [
-      "null",
-      "object"
-    ]
+    "type": ["null", "object"]
   },
   "line_item": {
     "properties": {
       "applied_discounts": {
         "items": {
-          "type": [
-            "null",
-            "object"
-          ]
+          "type": ["null", "object"]
         },
-        "type": [
-          "null",
-          "array"
-        ]
+        "type": ["null", "array"]
       },
       "total_discount_set": {},
       "pre_tax_price_set": {},
       "price_set": {},
       "grams": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       },
       "compare_at_price": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "destination_location_id": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       },
       "key": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "line_price": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "origin_location_id": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       },
       "applied_discount": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       },
       "fulfillable_quantity": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       },
       "variant_title": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "properties": {
         "anyOf": [
@@ -1138,27 +565,15 @@
             "items": {
               "properties": {
                 "name": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "value": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 }
               },
-              "type": [
-                "null",
-                "object"
-              ]
+              "type": ["null", "object"]
             },
-            "type": [
-              "null",
-              "array"
-            ]
+            "type": ["null", "array"]
           },
           {
             "properties": {},
@@ -1167,101 +582,56 @@
         ]
       },
       "tax_code": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "discount_allocations": {
         "items": {
           "properties": {
             "discount_application_index": {
-              "type": [
-                "null",
-                "integer"
-              ]
+              "type": ["null", "integer"]
             },
             "amount_set": {},
             "amount": {
-              "type": [
-                "null",
-                "number"
-              ]
+              "type": ["null", "number"]
             }
           },
-          "type": [
-            "null",
-            "object"
-          ]
+          "type": ["null", "object"]
         },
-        "type": [
-          "null",
-          "array"
-        ]
+        "type": ["null", "array"]
       },
       "admin_graphql_api_id": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "pre_tax_price": {
-        "type": [
-          "null",
-          "number"
-        ]
+        "type": ["null", "number"]
       },
       "sku": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "product_exists": {
-        "type": [
-          "null",
-          "boolean"
-        ]
+        "type": ["null", "boolean"]
       },
       "total_discount": {
-        "type": [
-          "null",
-          "string"
-        ],
+        "type": ["null", "string"],
         "format": "singer.decimal"
       },
       "name": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "fulfillment_status": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "gift_card": {
-        "type": [
-          "null",
-          "boolean"
-        ]
+        "type": ["null", "boolean"]
       },
       "id": {
         "type": ["null", "integer", "string"]
       },
       "taxable": {
-        "type": [
-          "null",
-          "boolean"
-        ]
+        "type": ["null", "boolean"]
       },
       "vendor": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "tax_lines": {
         "$ref": "definitions.json#/tax_lines"
@@ -1270,215 +640,118 @@
         "$ref": "definitions.json#/location"
       },
       "price": {
-        "type": [
-          "null",
-          "string"
-        ],
+        "type": ["null", "string"],
         "format": "singer.decimal"
       },
       "requires_shipping": {
-        "type": [
-          "null",
-          "boolean"
-        ]
+        "type": ["null", "boolean"]
       },
       "fulfillment_service": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "variant_inventory_management": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "title": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "destination_location": {
         "$ref": "definitions.json#/location"
       },
       "quantity": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       },
       "product_id": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       },
       "variant_id": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       },
       "duties": {}
     },
-    "patternProperties": {".+": {}},
-    "type": [
-      "null",
-      "object"
-    ]
+    "patternProperties": { ".+": {} },
+    "type": ["null", "object"]
   },
   "line_items": {
     "items": {
       "$ref": "definitions.json#/line_item"
     },
-    "type": [
-      "null",
-      "array"
-    ]
+    "type": ["null", "array"]
   },
   "image": {
     "properties": {
       "updated_at": {
-        "type": [
-          "null",
-          "string"
-        ],
+        "type": ["null", "string"],
         "format": "date-time"
       },
       "created_at": {
-        "type": [
-          "null",
-          "string"
-        ],
+        "type": ["null", "string"],
         "format": "date-time"
       },
       "variant_ids": {
-        "type": [
-          "null",
-          "array"
-        ],
+        "type": ["null", "array"],
         "items": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         }
       },
       "height": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       },
       "alt": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "src": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "position": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       },
       "id": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       },
       "admin_graphql_api_id": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
       "width": {
-        "type": [
-          "null",
-          "integer"
-        ]
+        "type": ["null", "integer"]
       }
     },
-    "type": [
-      "null",
-      "object"
-    ]
+    "type": ["null", "object"]
   },
   "tax_lines": {
     "items": {
       "properties": {
-        "price_set": {
-        },
+        "price_set": {},
         "price": {
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "singer.decimal"
         },
         "title": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "rate": {
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "singer.decimal"
         },
         "compare_at": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "position": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "source": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "zone": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "channel_liable": {
-          "type": [
-            "null",
-            "boolean"
-          ]
+          "type": ["null", "boolean"]
         }
       },
-      "patternProperties": {".+": {}},
-      "type": [
-        "null",
-        "object"
-      ]
+      "patternProperties": { ".+": {} },
+      "type": ["null", "object"]
     },
-    "type": [
-      "null",
-      "array"
-    ]
+    "type": ["null", "array"]
   }
 }

--- a/tap_shopify/schemas/orders.json
+++ b/tap_shopify/schemas/orders.json
@@ -1,10 +1,7 @@
 {
   "properties": {
     "presentment_currency": {
-        "type": [
-          "null",
-          "string"
-        ]
+      "type": ["null", "string"]
     },
     "subtotal_price_set": {},
     "total_discounts_set": {},
@@ -13,81 +10,51 @@
     "total_shipping_price_set": {},
     "total_tax_set": {},
     "current_subtotal_price_set": {
-      "type": [
-        "null",
-        "object"
-      ]
+      "type": ["null", "object"]
     },
     "current_total_duties_set": {
-      "type": [
-        "null",
-        "object"
-      ]
+      "type": ["null", "object"]
     },
     "current_total_discounts_set": {
-      "type": [
-        "null",
-        "object"
-      ]
+      "type": ["null", "object"]
     },
     "current_total_price_set": {
-      "type": [
-        "null",
-        "object"
-      ]
+      "type": ["null", "object"]
     },
     "current_total_tax_set": {
-      "type": [
-        "null",
-        "object"
-      ]
+      "type": ["null", "object"]
     },
     "original_total_duties_set": {
-      "type": [
-        "null",
-        "object"
-      ]
+      "type": ["null", "object"]
     },
     "total_price": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "singer.decimal"
     },
     "line_items": {
       "$ref": "definitions.json#/line_items"
     },
     "processing_method": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "order_number": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "confirmed": {
-      "type": [
-        "null",
-        "boolean"
-      ]
+      "type": ["null", "boolean"]
+    },
+    "taxExempt": {
+      "type": ["null", "boolean"]
+    },
+    "poNumber": {
+      "type": ["null", "string"]
     },
     "total_discounts": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "singer.decimal"
     },
     "total_line_items_price": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "singer.decimal"
     },
     "order_adjustments": {
@@ -100,186 +67,99 @@
             "$ref": "definitions.json#/tax_lines"
           },
           "phone": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "discounted_price_set": {},
           "price_set": {},
           "price": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "singer.decimal"
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "discount_allocations": {
             "items": {
               "properties": {
                 "discount_application_index": {
-                  "type": [
-                    "null",
-                    "integer"
-                  ]
+                  "type": ["null", "integer"]
                 },
                 "amount": {
-                  "type": [
-                    "null",
-                    "number"
-                  ]
+                  "type": ["null", "number"]
                 }
               },
-              "type": [
-                "null",
-                "object"
-              ]
+              "type": ["null", "object"]
             },
-            "type": [
-              "null",
-              "array"
-            ]
+            "type": ["null", "array"]
           },
           "delivery_category": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "discounted_price": {
-            "type": [
-              "null",
-              "number"
-            ]
+            "type": ["null", "number"]
           },
           "code": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "requested_fulfillment_service_id": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "carrier_identifier": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "id": {
-            "type": [
-              "null",
-              "integer"
-            ]
+            "type": ["null", "integer"]
           },
           "source": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         },
-        "type": [
-          "null",
-          "object"
-        ]
+        "type": ["null", "object"]
       },
-      "type": [
-        "null",
-        "array"
-      ]
+      "type": ["null", "array"]
     },
     "admin_graphql_api_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "device_id": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "cancel_reason": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "currency": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "payment_gateway_names": {
       "items": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       },
-      "type": [
-        "null",
-        "array"
-      ]
+      "type": ["null", "array"]
     },
     "source_identifier": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "id": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "processed_at": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "date-time"
     },
     "referring_site": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "contact_email": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "location_id": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "fulfillments": {
       "items": {
         "properties": {
           "location_id": {
-            "type": [
-              "null",
-              "integer"
-            ]
+            "type": ["null", "integer"]
           },
           "receipt": {
             "type": ["null", "object"],
@@ -293,727 +173,382 @@
             }
           },
           "tracking_number": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "created_at": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "shipment_status": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "line_items": {
             "$ref": "definitions.json#/line_items"
           },
           "tracking_url": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "service": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "admin_graphql_api_id": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "tracking_urls": {
             "items": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
-            "type": [
-              "null",
-              "array"
-            ]
+            "type": ["null", "array"]
           },
           "tracking_numbers": {
             "items": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             },
-            "type": [
-              "null",
-              "array"
-            ]
+            "type": ["null", "array"]
           },
           "id": {
-            "type": [
-              "null",
-              "integer"
-            ]
+            "type": ["null", "integer"]
           },
           "tracking_company": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "updated_at": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           }
         },
-        "type": [
-          "null",
-          "object"
-        ]
+        "type": ["null", "object"]
       },
-      "type": [
-        "null",
-        "array"
-      ]
+      "type": ["null", "array"]
     },
     "customer": {
       "$ref": "definitions.json#/customer_orders"
     },
     "test": {
-      "type": [
-        "null",
-        "boolean"
-      ]
+      "type": ["null", "boolean"]
     },
     "total_tax": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "singer.decimal"
     },
     "payment_details": {
       "properties": {
         "avs_result_code": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "credit_card_company": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "cvv_result_code": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "credit_card_bin": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "credit_card_number": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         }
       },
-      "type": [
-        "null",
-        "object"
-      ]
+      "type": ["null", "object"]
     },
     "number": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "email": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "source_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "landing_site_ref": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "shipping_address": {
       "properties": {
         "phone": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "country": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "name": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "address1": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "longitude": {
-          "type": [
-            "null",
-            "number"
-          ]
+          "type": ["null", "number"]
         },
         "address2": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "last_name": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "first_name": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "province": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "city": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "company": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "latitude": {
-          "type": [
-            "null",
-            "number"
-          ]
+          "type": ["null", "number"]
         },
         "country_code": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "province_code": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "zip": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         }
       },
-      "type": [
-        "null",
-        "object"
-      ]
+      "type": ["null", "object"]
     },
     "total_price_usd": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "singer.decimal"
     },
     "closed_at": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "date-time"
     },
     "discount_applications": {
       "items": {
         "properties": {
           "target_type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "code": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "description": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "target_selection": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "allocation_method": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "value_type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "value": {
-            "type": [
-              "null",
-              "number"
-            ]
+            "type": ["null", "number"]
           }
         },
-        "type": [
-          "null",
-          "object"
-        ]
+        "type": ["null", "object"]
       },
-      "type": [
-        "null",
-        "array"
-      ]
+      "type": ["null", "array"]
     },
     "name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "note": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "user_id": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "source_url": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "subtotal_price": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "singer.decimal"
     },
     "billing_address": {
       "properties": {
         "phone": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "country": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "name": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "address1": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "longitude": {
-          "type": [
-            "null",
-            "number"
-          ]
+          "type": ["null", "number"]
         },
         "address2": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "last_name": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "first_name": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "province": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "city": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "company": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "latitude": {
-          "type": [
-            "null",
-            "number"
-          ]
+          "type": ["null", "number"]
         },
         "country_code": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "province_code": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "zip": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         }
       },
-      "type": [
-        "null",
-        "object"
-      ]
+      "type": ["null", "object"]
     },
     "landing_site": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "taxes_included": {
-      "type": [
-        "null",
-        "boolean"
-      ]
+      "type": ["null", "boolean"]
     },
     "token": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "app_id": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "total_tip_received": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "browser_ip": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "discount_codes": {
       "items": {
         "properties": {
           "code": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "amount": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "singer.decimal"
           },
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         },
-        "type": [
-          "null",
-          "object"
-        ]
+        "type": ["null", "object"]
       },
-      "type": [
-        "null",
-        "array"
-      ]
+      "type": ["null", "array"]
     },
     "tax_lines": {
       "$ref": "definitions.json#/tax_lines"
     },
     "phone": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "note_attributes": {
       "items": {
         "properties": {
           "name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "value": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         },
-        "type": [
-          "null",
-          "object"
-        ]
+        "type": ["null", "object"]
       },
-      "type": [
-        "null",
-        "array"
-      ]
+      "type": ["null", "array"]
     },
     "fulfillment_status": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "order_status_url": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "client_details": {
       "properties": {
         "session_hash": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "accept_language": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "browser_width": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "user_agent": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "browser_ip": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "browser_height": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         }
       },
-      "type": [
-        "null",
-        "object"
-      ]
+      "type": ["null", "object"]
     },
     "buyer_accepts_marketing": {
-      "type": [
-        "null",
-        "boolean"
-      ]
+      "type": ["null", "boolean"]
     },
     "checkout_token": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "tags": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "financial_status": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "customer_locale": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "checkout_id": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "total_weight": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "gateway": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "cart_token": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "cancelled_at": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "date-time"
     },
     "refunds": {
       "items": {
         "properties": {
           "admin_graphql_api_id": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "refund_line_items": {
             "items": {
@@ -1022,262 +557,140 @@
                   "$ref": "definitions.json#/line_item"
                 },
                 "location_id": {
-                  "type": [
-                    "null",
-                    "integer"
-                  ]
+                  "type": ["null", "integer"]
                 },
                 "line_item_id": {
-                  "type": [
-                    "null",
-                    "integer"
-                  ]
+                  "type": ["null", "integer"]
                 },
                 "quantity": {
-                  "type": [
-                    "null",
-                    "integer"
-                  ]
+                  "type": ["null", "integer"]
                 },
                 "id": {
-                  "type": [
-                    "null",
-                    "integer"
-                  ]
+                  "type": ["null", "integer"]
                 },
                 "total_tax": {
-                  "type": [
-                    "null",
-                    "number"
-                  ]
+                  "type": ["null", "number"]
                 },
                 "restock_type": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "subtotal": {
-                  "type": [
-                    "null",
-                    "number"
-                  ]
+                  "type": ["null", "number"]
                 }
               },
-              "type": [
-                "null",
-                "object"
-              ]
+              "type": ["null", "object"]
             },
-            "type": [
-              "null",
-              "array"
-            ]
+            "type": ["null", "array"]
           },
           "restock": {
-            "type": [
-              "null",
-              "boolean"
-            ]
+            "type": ["null", "boolean"]
           },
           "note": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "id": {
-            "type": [
-              "null",
-              "integer"
-            ]
+            "type": ["null", "integer"]
           },
           "user_id": {
-            "type": [
-              "null",
-              "integer"
-            ]
+            "type": ["null", "integer"]
           },
           "created_at": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "processed_at": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "order_adjustments": {
             "$ref": "definitions.json#/order_adjustments"
           }
         },
-        "type": [
-          "null",
-          "object"
-        ]
+        "type": ["null", "object"]
       },
-      "type": [
-        "null",
-        "array"
-      ]
+      "type": ["null", "array"]
     },
     "created_at": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "date-time"
     },
     "updated_at": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "date-time"
     },
     "reference": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "current_subtotal_price": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "singer.decimal"
     },
     "current_total_discounts": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "singer.decimal"
     },
     "current_total_price": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "singer.decimal"
     },
     "current_total_tax": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "singer.decimal"
     },
     "total_outstanding": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "singer.decimal"
     },
     "payment_terms": {
-      "type": [
-        "null",
-        "object"
-      ],
+      "type": ["null", "object"],
       "properties": {
         "amount": {
-          "type": [
-            "null",
-            "integer",
-            "string"
-          ]
+          "type": ["null", "integer", "string"]
         },
         "currency": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "due_in_days": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "payment_schedules": {
-          "type": [
-            "null",
-            "array"
-          ],
+          "type": ["null", "array"],
           "items": {
             "properties": {
               "amount": {
-                "type": [
-                  "null",
-                  "integer",
-                  "string"
-                ]
+                "type": ["null", "integer", "string"]
               },
               "due_at": {
-                "type": [
-                  "null",
-                  "string"
-                ],
+                "type": ["null", "string"],
                 "format": "date-time"
               },
               "currency": {
-                "type": [
-                  "null",
-                  "string"
-                ]
+                "type": ["null", "string"]
               },
               "issued_at": {
-                "type": [
-                  "null",
-                  "string"
-                ],
+                "type": ["null", "string"],
                 "format": "date-time"
               },
               "completed_at": {
-                "type": [
-                  "null",
-                  "string"
-                ]
+                "type": ["null", "string"]
               },
               "expected_payment_method": {
-                "type": [
-                  "null",
-                  "string"
-                ]
+                "type": ["null", "string"]
               }
             },
-            "type": [
-              "null",
-              "object"
-            ]
+            "type": ["null", "object"]
           }
         },
         "payment_terms_name": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "payment_terms_type": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         }
       }
     },
     "estimated_taxes": {
-      "type": [
-        "null",
-        "boolean"
-      ]
+      "type": ["null", "boolean"]
     }
   },
   "type": "object"

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -96,5 +96,8 @@ class AllFieldsTest(BaseTapTest):
                     # No field named 'order_adjustments' present in the 'order' object
                     #   Documentation: https://shopify.dev/api/admin-rest/2021-10/resources/order#resource_object
                     expected_all_keys.remove('order_adjustments')
-
+                    # missing data for 'taxExempt' and 'poNumber' in 'orders' stream
+                    # https://jira.talendforge.org/browse/TDL-25173
+                    missing_fields = {'taxExempt', 'poNumber'}
+                    expected_all_keys = expected_all_keys - missing_fields
                 self.assertSetEqual(expected_all_keys, actual_all_keys)


### PR DESCRIPTION
# Description of change
This PR details the required version update to **2024-01** which aligns with the mandatory version from Shopify. Related change has also been made to _shopify_python_api_ to corporate the new changes( changes mentioned in [shopify_python_api](https://github.com/Peliqan-io/shopify_python_api/pull/1) )

NOTE: Changes have been made with reference to commits on root repo detailed in [tap-shopify commits](https://github.com/singer-io/tap-shopify/commit/df35a37cd1289e304abf18809458f664429efc42)

# Changes
1. Updated Requirements and changed semantic version in setup.py
2. Changes released version in __init__.py
3.  Added two keys "taxExempt" and "PONumber" to orders schema
4.  removed two fields from definitions.json
5. small change to incorporate missing fields has been added to test_all_fields.py

# Testing
 Testing has been performed with required configurations and dependencies.

# Risks
New changes might affect old connections, need to perform FULL-RESYNC.

# Rollback steps
 - revert this branch

# ChangeType
:white_large_square: New feature (non-breaking change which adds functionality)
⬜ : Bug fix (non-breaking change which fixes an issue)
✅ : Refactor
:white_large_square: Breaking change (fix or feature that would cause existing functionality to not work as expected)
:white_large_square: This change requires a documentation update (edited)